### PR TITLE
Add copyright and GPLv3-or-later notices to source files

### DIFF
--- a/ATCwatch/ATCwatch.ino
+++ b/ATCwatch/ATCwatch.ino
@@ -1,9 +1,8 @@
-
-
-//You can use and edit the code as long as you mention me (Aaron Christophel and https://ATCnetz.de) in the source and somewhere in the menu of the working firmware, even when using small peaces of the code. :)
-//If you want to use the code or parts of it commercial please write an email to: info@atcnetz.de
-
-//This code uses the BMA421 Library wich is made by Bosch and this is under copyright by Bosch Sensortech GmbH
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "pinout.h"
 #include "watchdog.h"

--- a/ATCwatch/accl.cpp
+++ b/ATCwatch/accl.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "accl.h"
 #include "Arduino.h"
 #include "i2c.h"

--- a/ATCwatch/accl.h
+++ b/ATCwatch/accl.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/backlight.cpp
+++ b/ATCwatch/backlight.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "backlight.h"
 #include "Arduino.h"

--- a/ATCwatch/backlight.h
+++ b/ATCwatch/backlight.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/battery.cpp
+++ b/ATCwatch/battery.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "battery.h"
 #include "Arduino.h"

--- a/ATCwatch/battery.h
+++ b/ATCwatch/battery.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/ble.cpp
+++ b/ATCwatch/ble.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "ble.h"
 #include "pinout.h"
 #include <BLEPeripheral.h>

--- a/ATCwatch/ble.h
+++ b/ATCwatch/ble.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 
 #include "Arduino.h"

--- a/ATCwatch/bootloader.cpp
+++ b/ATCwatch/bootloader.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "bootloader.h"
 #include "pinout.h"

--- a/ATCwatch/bootloader.h
+++ b/ATCwatch/bootloader.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/class.h
+++ b/ATCwatch/class.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/display.cpp
+++ b/ATCwatch/display.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "display.h"
 
 #include <lvgl.h>

--- a/ATCwatch/display.h
+++ b/ATCwatch/display.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/fast_spi.cpp
+++ b/ATCwatch/fast_spi.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "fast_spi.h"
 #include "pinout.h"

--- a/ATCwatch/fast_spi.h
+++ b/ATCwatch/fast_spi.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/flash.cpp
+++ b/ATCwatch/flash.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "flash.h"
 #include "pinout.h"
 #include "fast_spi.h"

--- a/ATCwatch/flash.h
+++ b/ATCwatch/flash.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/heartrate.cpp
+++ b/ATCwatch/heartrate.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "heartrate.h"
 #include "pinout.h"

--- a/ATCwatch/heartrate.h
+++ b/ATCwatch/heartrate.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/i2c.cpp
+++ b/ATCwatch/i2c.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include <Arduino.h>
 #include "pinout.h"
 #include "i2c.h"

--- a/ATCwatch/i2c.h
+++ b/ATCwatch/i2c.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 
 #include <Arduino.h>

--- a/ATCwatch/inputoutput.cpp
+++ b/ATCwatch/inputoutput.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "inputoutput.h"
 #include "Arduino.h"

--- a/ATCwatch/inputoutput.h
+++ b/ATCwatch/inputoutput.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/interrupt.cpp
+++ b/ATCwatch/interrupt.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "interrupt.h"
 #include "pinout.h"

--- a/ATCwatch/interrupt.h
+++ b/ATCwatch/interrupt.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/menu.cpp
+++ b/ATCwatch/menu.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "menu.h"
 #include "class.h"

--- a/ATCwatch/menu.h
+++ b/ATCwatch/menu.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 
 #include "Arduino.h"

--- a/ATCwatch/menu_Accl.h
+++ b/ATCwatch/menu_Accl.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Animation.h
+++ b/ATCwatch/menu_Animation.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_App.h
+++ b/ATCwatch/menu_App.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Battery.h
+++ b/ATCwatch/menu_Battery.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Boot.h
+++ b/ATCwatch/menu_Boot.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Charging.h
+++ b/ATCwatch/menu_Charging.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Debug.h
+++ b/ATCwatch/menu_Debug.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 #include "Arduino.h"
 #include "class.h"

--- a/ATCwatch/menu_Demo.h
+++ b/ATCwatch/menu_Demo.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Flash.h
+++ b/ATCwatch/menu_Flash.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Heart.h
+++ b/ATCwatch/menu_Heart.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Home.h
+++ b/ATCwatch/menu_Home.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Http.h
+++ b/ATCwatch/menu_Http.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Log.h
+++ b/ATCwatch/menu_Log.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Notify.h
+++ b/ATCwatch/menu_Notify.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Off.h
+++ b/ATCwatch/menu_Off.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Reboot.h
+++ b/ATCwatch/menu_Reboot.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Settings.h
+++ b/ATCwatch/menu_Settings.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Settings_Brightness.h
+++ b/ATCwatch/menu_Settings_Brightness.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Settings_Color.h
+++ b/ATCwatch/menu_Settings_Color.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Settings_Date.h
+++ b/ATCwatch/menu_Settings_Date.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Settings_Time.h
+++ b/ATCwatch/menu_Settings_Time.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Touch.h
+++ b/ATCwatch/menu_Touch.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_Update.h
+++ b/ATCwatch/menu_Update.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/menu_infos.h
+++ b/ATCwatch/menu_infos.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 #include "Arduino.h"

--- a/ATCwatch/pinout.h
+++ b/ATCwatch/pinout.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #ifndef _PINOUT_
 #define _PINOUT_

--- a/ATCwatch/push.cpp
+++ b/ATCwatch/push.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "Arduino.h"
 #include "sleep.h"

--- a/ATCwatch/push.h
+++ b/ATCwatch/push.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/screen_style.h
+++ b/ATCwatch/screen_style.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #pragma once
 
 #include "Arduino.h"

--- a/ATCwatch/sleep.cpp
+++ b/ATCwatch/sleep.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "sleep.h"
 #include "Arduino.h"

--- a/ATCwatch/sleep.h
+++ b/ATCwatch/sleep.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/tasks.cpp
+++ b/ATCwatch/tasks.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "tasks.h"
 #include "pinout.h"

--- a/ATCwatch/tasks.h
+++ b/ATCwatch/tasks.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/time.cpp
+++ b/ATCwatch/time.cpp
@@ -1,4 +1,8 @@
-
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "Arduino.h"
 #include "sleep.h"

--- a/ATCwatch/time.h
+++ b/ATCwatch/time.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/touch.cpp
+++ b/ATCwatch/touch.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "touch.h"
 #include "Arduino.h"
 #include "pinout.h"

--- a/ATCwatch/touch.h
+++ b/ATCwatch/touch.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 

--- a/ATCwatch/watchdog.cpp
+++ b/ATCwatch/watchdog.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #include "watchdog.h"
 #include "pinout.h"

--- a/ATCwatch/watchdog.h
+++ b/ATCwatch/watchdog.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020 Aaron Christophel
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 #pragma once
 


### PR DESCRIPTION
It's good practice in general, and recommended in the GPLv3 license, to specify copyright, year and exact licensing conditions in each source file. This patch uses the machine-readable [SPDX identifier](https://spdx.org/licenses/), which is a new standard to unambiguously know the license and to keep things short. The **or-later** part is explained [here](https://www.gnu.org/licenses/identify-licenses-clearly.html).

If anyone makes significant changes to any of the files, they are supposed to add their name below yours in a separate copyright line.

I didn't add notices to some of the files that appear to be machine-generated.