### PR TITLE
Fix ic_launcher.png.license and update README

### DIFF
--- a/ATCwatch/icons/ic_launcher.png.license
+++ b/ATCwatch/icons/ic_launcher.png.license
@@ -1,4 +1,3 @@
-Bootlogo from here:
-https://github.com/google/material-design-icons/blob/master/hardware/drawable-hdpi/ic_watch_black_18dp.png
-
 Copyright (c) 2015 Material Design Authors
+
+SPDX-License-Identifier: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,53 +1,55 @@
 # ATCwatch  -WatcH
 Custom Arduino C++ firmware for the P8 and PineTime plus many more DaFit Smartwatches
 
-About 150-200uA standby current consumtion.Currently 92 Hours Runtime with heavy notification and usage!.
+About 150–200uA standby current consumtion. Currently 92 Hours Runtime with heavy notification and usage!
 Basic menu system and notification working.
 
 If you want to use it on PineTime comment the #define P8WATCH to enable the PineTime Pinout. 
-For other watches please try to check the pinout of them and change the pinout as needed.
+For other watches please try to check the pinout of them and make changes as needed.
 
-#### You can support my work via paypal: https://paypal.me/hoverboard1 this keeps projects like this comming.
+**You can support my work via paypal: https://paypal.me/hoverboard1 This keeps projects like this coming.**
 
-Use this portable Arduino version: https://atcnetz.de/downloads/D6Arduino.rar
-here is a manual on how to use it: https://youtu.be/3gjmEdEDJ5A
-Unzip, open Arduino.exe open the ATCwatch.ino file and compile. Done
-Simply select the DaFit as the board and click on compile, you will get an Update file you can flash in the Arduino folder.
+Use this portable Arduino version:
+- https://atcnetz.de/downloads/D6Arduino.rar
 
-Please make shure you have always an option to go back to Bootlaoder somehow, i can only suggest to have one watch opened and connected an SWD St-Link V2 to it to develope on that.
+Here is a manual on how to use it:
+- https://youtu.be/3gjmEdEDJ5A
+
+Unzip, open Arduino.exe, open the ATCwatch.ino file and compile. Done.
+Simply select the DaFit as the board and click on compile. You will get an Update file you can flash in the Arduino folder.
+
+Please make sure you have always an option to go back to Bootloader somehow. I can only suggest to have one watch opened and connected an SWD St-Link V2 to it to develop on that.
 
 
-#### This can be flashed without opening the Watch with this Repo https://github.com/atc1441/DaFlasherFiles and the DaFlasher app from the PlayStore(Android):
-https://play.google.com/store/apps/details?id=com.atcnetz.paatc.patc&hl=en_US
+**This can be flashed without opening the Watch with this Repo https://github.com/atc1441/DaFlasherFiles and the DaFlasher app from the PlayStore (Android):**
+- https://play.google.com/store/apps/details?id=com.atcnetz.paatc.patc&hl=en_US
+- https://www.youtube.com/watch?v=gUVEz-pxhgg
 
-https://www.youtube.com/watch?v=gUVEz-pxhgg
+This firmware is meant to be used with the D6Notification App from the PlayStore (Android):
+- https://play.google.com/store/apps/details?id=com.atcnetz.de.notification&hl=gsw
 
-This firmware is meant to be used with the D6Notification App from the PlayStore(Android):
-https://play.google.com/store/apps/details?id=com.atcnetz.de.notification&hl=gsw
+## Credits
+Many Thanks to Daniel Thompson (https://github.com/daniel-thompson/wasp-os) for giving the Hint with the BMA423 Library. This way interrupts are finally possible with it.
 
-## Credits:
-Many Thanks to Daniel Thompson(https://github.com/daniel-thompson/wasp-os) to giving the Hint with the BMA423 Library
-This way interrupts are finally possible with it.
-
-Also many Thanks to https://github.com/endian-albin for helping so much with the Licensing 
+Also many Thanks to https://github.com/endian-albin for helping so much with the Licensing.
 
 ## Copyright and licenses
 
-This program is created by Aaron Christophel and made available the GNU General Public License version 3 or, at your option, any later version.
+This program is created by Aaron Christophel and made available under the GNU General Public License version 3 or, at your option, any later version.
 
-It makes use of the BMA423 Library which is copyrighted by Bosch Sensortech GmbH and under the BSD-3-Clause license.
-https://github.com/BoschSensortec/BMA423-Sensor-API
+It makes use of the BMA423 Library which is copyrighted by Bosch Sensortech GmbH and under the BSD-3-Clause license:
+- https://github.com/BoschSensortec/BMA423-Sensor-API
 
-The icons used are under the Apache License 2.0 and taken from here:
-https://github.com/Remix-Design/RemixIcon
-https://github.com/romannurik/AndroidAssetStudio (the boot logo)
+The icons are under the Apache License 2.0 and taken from here:
+- https://github.com/Remix-Design/RemixIcon
+- https://github.com/google/material-design-icons/ (the boot logo)
 
 The Montserrat font is under the SIL Open Font License, Version 1.1 and taken from here:
-https://fonts.google.com/specimen/Montserrat
+- https://fonts.google.com/specimen/Montserrat
 
 ## FAQ / Errors
 #### Code does not compile / Arduino puts out errors.
----> This code is meant to be used with the D6Arduino.rar on Windows and is tested that way, sometimes i make changes to the D6Arduino.rar so you need to update that also when getting the newest firmware, i will try to add information when you need to update it but can not guaranty this info, so just try an update if it does not work.
+---> This code is meant to be used with the D6Arduino.rar on Windows and is tested that way. Sometimes I make changes to it so you need to update that also when getting the newest firmware. I will try to add information when you need to update it but can not guarantee it, so just try an update if it does not work.
 
 The latest update that needs the newest D6Arduino.rar file is this: https://github.com/atc1441/ATCwatch/commit/0dd3138d10d5c8f1a776ad1b7f1d4819d686e46f
 


### PR DESCRIPTION
This fixes the ic_launcher.png.license and some language and style issues that I found in the README.

When it comes to REUSE compliance, the only remaining issues are these two:
```
# MISSING COPYRIGHT AND LICENSING INFORMATION
The following files have no copyright and licensing information:
* ATCwatch/fonts.h
The following files have no licensing information:
* ATCwatch/fonts/078MKMC_.TTF
```